### PR TITLE
[backend] PostStatus 갱신 API 수정

### DIFF
--- a/src/docs/asciidoc/post.adoc
+++ b/src/docs/asciidoc/post.adoc
@@ -58,6 +58,8 @@ include::{snippets}/post_detail/response-fields.adoc[]
 === 게시글 목록 조회
 `GET /api/posts`
 
+- kinds, status, skill, region, keywords는 필요에 따라 사용가능
+
 요청 HTTP
 include::{snippets}/post_list/http-request.adoc[]
 include::{snippets}/post_list/request-parameters.adoc[]
@@ -116,14 +118,14 @@ include::{snippets}/post_complete/request-parts.adoc[]
 include::{snippets}/post_complete/http-response.adoc[]
 include::{snippets}/post_complete/response-fields.adoc[]
 
-=== 게시물 상태 변화 작성 및 수정
-`PUT /api/post/{postId}/changeStatus`
+=== 게시물 상태 수정
+`POST /api/post/{postId}/update?status=POSTSTATUS`
 
 요청 HTTP
-include::{snippets}/post_chageStatus/http-request.adoc[]
-include::{snippets}/post_chageStatus/path-parameters.adoc[]
-include::{snippets}/post_chageStatus/request-fields.adoc[]
+include::{snippets}/post_updateStatus/http-request.adoc[]
+include::{snippets}/post_updateStatus/path-parameters.adoc[]
+include::{snippets}/post_updateStatus/request-parameters.adoc[]
 
 성공 응답 HTTP
-include::{snippets}/post_chageStatus/http-response.adoc[]
-include::{snippets}/post_chageStatus/response-fields.adoc[]
+include::{snippets}/post_updateStatus/http-response.adoc[]
+include::{snippets}/post_updateStatus/response-fields.adoc[]

--- a/src/main/java/com/rubminds/api/post/domain/Post.java
+++ b/src/main/java/com/rubminds/api/post/domain/Post.java
@@ -2,6 +2,7 @@ package com.rubminds.api.post.domain;
 
 import com.rubminds.api.common.domain.BaseEntity;
 import com.rubminds.api.post.dto.PostRequest;
+import com.rubminds.api.post.exception.PostStateException;
 import com.rubminds.api.skill.domain.CustomSkill;
 import com.rubminds.api.team.domain.Team;
 import com.rubminds.api.team.exception.TeamOutOfBoundException;
@@ -87,9 +88,9 @@ public class Post extends BaseEntity {
         this.kinds = request.getKinds();
     }
 
-    public void changeStatus(PostRequest.ChangeStatus request) {
-        this.postStatus = request.getPostStatus();
-    }
+//    public void changeStatus(PostRequest.ChangeStatus request) {
+//        this.postStatus = request.getPostStatus();
+//    }
 
     public void updateComplete(PostRequest.CreateCompletePost request) {
         this.completeContent = request.getCompleteContent();
@@ -116,5 +117,11 @@ public class Post extends BaseEntity {
 
     public void updateStatus(PostStatus postStatus) {
         this.postStatus = postStatus;
+    }
+
+    public void statusValidate(){
+        if (!this.postStatus.equals(PostStatus.RANKING)){
+            throw new PostStateException();
+        }
     }
 }

--- a/src/main/java/com/rubminds/api/post/exception/PostStateException.java
+++ b/src/main/java/com/rubminds/api/post/exception/PostStateException.java
@@ -1,0 +1,9 @@
+package com.rubminds.api.post.exception;
+
+import com.rubminds.api.common.exception.InvalidValueException;
+
+public class PostStateException extends InvalidValueException {
+    public PostStateException(){
+        super("진행종료 단계가 아닙니다.");
+    }
+}

--- a/src/main/java/com/rubminds/api/post/service/PostService.java
+++ b/src/main/java/com/rubminds/api/post/service/PostService.java
@@ -136,13 +136,22 @@ public class PostService {
         return PostResponse.OnlyId.build(post);
     }
 
-    @Transactional
-    public PostResponse.OnlyId changeStatus(Long postId, PostRequest.ChangeStatus request, User loginUser) {
-        Post post = postRepository.findById(postId).orElseThrow(PostNotFoundException::new);
-        loginUser.isAdmin(post.getWriter().getId());
-        post.changeStatus(request);
+//    @Transactional
+//    public PostResponse.OnlyId changeStatus(Long postId, PostRequest.ChangeStatus request, User loginUser) {
+//        Post post = postRepository.findById(postId).orElseThrow(PostNotFoundException::new);
+//        loginUser.isAdmin(post.getWriter().getId());
+//        post.changeStatus(request);
+//
+//        return PostResponse.OnlyId.build(post);
+//    }
 
-        return PostResponse.OnlyId.build(post);
+    @Transactional
+    public PostResponse.Info updateStatus(Long postId, PostStatus postStatus, CustomUserDetails customUserDetails) {
+        Post post = postRepository.findById(postId).orElseThrow(PostNotFoundException::new);
+        User user = customUserDetails.getUser();
+        user.isAdmin(post.getWriter().getId());
+        post.updateStatus(postStatus);
+        return PostResponse.Info.build(post, customUserDetails);
     }
 
     public void isFinished(Post post, Integer finishNum) {

--- a/src/main/java/com/rubminds/api/post/web/PostController.java
+++ b/src/main/java/com/rubminds/api/post/web/PostController.java
@@ -76,11 +76,18 @@ public class PostController {
         return ResponseEntity.ok().body(response);
     }
 
-    @PutMapping("/post/{postId}/changeStatus")
-    public ResponseEntity<PostResponse.OnlyId> chanegStatus (@PathVariable Long postId, @RequestBody PostRequest.ChangeStatus request, @CurrentUser CustomUserDetails customUserDetails) {
-        PostResponse.OnlyId response = postService.changeStatus(postId, request, customUserDetails.getUser());
+    @PostMapping("/post/{postId}/update")
+    public ResponseEntity<PostResponse.Info> updateStatus(@PathVariable Long postId, @RequestParam(value = "status")PostStatus postStatus, @CurrentUser CustomUserDetails customUserDetails) {
+        PostResponse.Info response = postService.updateStatus(postId, postStatus, customUserDetails);
         return ResponseEntity.ok().body(response);
     }
+
+//    @PutMapping("/post/{postId}/changeStatus")
+//    public ResponseEntity<PostResponse.OnlyId> chanegStatus (@PathVariable Long postId, @RequestBody PostRequest.ChangeStatus request, @CurrentUser CustomUserDetails customUserDetails) {
+//        PostResponse.OnlyId response = postService.changeStatus(postId, request, customUserDetails.getUser());
+//        return ResponseEntity.ok().body(response);
+//    }
+
 
 //    @DeleteMapping("/post/{postId}")
 //    public ResponseEntity<Void> delete(@PathVariable("postId") Long postId) {

--- a/src/main/java/com/rubminds/api/team/service/TeamUserService.java
+++ b/src/main/java/com/rubminds/api/team/service/TeamUserService.java
@@ -56,6 +56,9 @@ public class TeamUserService {
         TeamUser evaluator = teamUserRepository.findByUserAndTeam(user, team).orElseThrow(TeamUserNotFoundException::new);
         evaluator.validate();
 
+        Post post = postRepository.findByTeam(team).orElseThrow(PostNotFoundException::new);
+        post.statusValidate();
+
         for(int i = 0 ; i<request.getEvaluation().size(); i++){
             User targetUser = userRepository.findById(request.getEvaluation().get(i).getUserId()).orElseThrow(UserNotFoundException::new);
             targetUser.updateAttendLevel(request.getEvaluation().get(i).getAttendLevel());
@@ -65,7 +68,6 @@ public class TeamUserService {
         }
         evaluator.updateFinish();
 
-        Post post = postRepository.findByTeam(team).orElseThrow(PostNotFoundException::new);
         Integer countTeamUser = teamUserRepository.countAllByTeam(team);
         Integer countFinished = teamUserRepository.countAllByTeamAndFinishIsTrue(team);
         if(countTeamUser.equals(countFinished)){

--- a/src/rest/AuthController.http
+++ b/src/rest/AuthController.http
@@ -2,7 +2,7 @@ POST {{apiUrl}}/user/login
 Content-Type: application/json;charset=UTF-8
 
 {
-  "id": "2"
+  "id": "1"
 }
 
 > {%

--- a/src/rest/PostController.http
+++ b/src/rest/PostController.http
@@ -7,6 +7,10 @@ GET {{apiUrl}}/posts?kinds=PROJECT&region=서울&skill=1&skill=5&keywords=a&page
 Authorization: {{authorizationToken}}
 
 ###
+GET {{apiUrl}}/posts?status=RECRUIT&page=1&size=5
+Authorization: {{authorizationToken}}
+
+###
 GET {{apiUrl}}/posts/like?kinds=SCOUT&page=1&size=5
 Authorization: {{authorizationToken}}
 Content-Type: application/json;charset=UTF-8
@@ -101,12 +105,19 @@ Content-Type: image/jpeg
 
 < ./../main/resources/dummy/image/white.jpeg
 
+###
+POST {{apiUrl}}/post/1/update?status=WORKING
+Authorization: {{authorizationToken}}
 
 ###
-PUT {{apiUrl}}/post/1/changeStatus
+POST {{apiUrl}}/post/1/update?status=RANKING
 Authorization: {{authorizationToken}}
-Content-Type: application/json;charset=UTF-8
 
-{
-  "postStatus" : "RANKING"
-}
+####
+#PUT {{apiUrl}}/post/1/changeStatus
+#Authorization: {{authorizationToken}}
+#Content-Type: application/json;charset=UTF-8
+#
+#{
+#  "postStatus" : "RANKING"
+#}

--- a/src/test/java/com/rubminds/api/post/web/PostControllerTest.java
+++ b/src/test/java/com/rubminds/api/post/web/PostControllerTest.java
@@ -40,8 +40,7 @@ import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -390,31 +389,47 @@ public class PostControllerTest extends MvcTest {
 
     @Test
     @DisplayName("게시물 상태 변화시키기")
-    public void changePostStatus() throws Exception {
-        PostRequest.ChangeStatus request = PostRequest.ChangeStatus.builder().postStatus(PostStatus.WORKING).build();
+    public void updatePostStatus() throws Exception {
+        CustomUserDetails customUserDetails = CustomUserDetails.create(user);
 
-        PostResponse.OnlyId response = PostResponse.OnlyId.build(post1);
-        given(postService.changeStatus(any(), any(), any())).willReturn(response);
+        post1.updateStatus(PostStatus.WORKING);
+        PostResponse.Info response = PostResponse.Info.build(post1, customUserDetails);
 
-        ResultActions results = mvc.perform(RestDocumentationRequestBuilders
-                .put("/api/post/{postId}/changeStatus", 1L)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request))
-                .characterEncoding("UTF-8"));
+        given(postService.updateStatus(any(), any(), any())).willReturn(response);
+
+        ResultActions results = mvc.perform(RestDocumentationRequestBuilders.post("/api/post/{postId}/update", 1L)
+                        .param("status", "WORKING"));
 
         results.andExpect(status().isOk())
                 .andDo(print())
-                .andDo(document("post_chageStatus",
+                .andDo(document("post_updateStatus",
                         pathParameters(
                                 parameterWithName("postId").description("게시물 식별자")
                         ),
-                        requestFields(
-                                fieldWithPath("postStatus").type(JsonFieldType.STRING).description("상태변화시킬값(RECRUIT, WORKING, RANKING, FINISHED),")
+                        requestParameters(
+                                parameterWithName("status").description("변화하고자 하는 포스트상태(WORKING, RANKING)")
 
                         ),
                         relaxedResponseFields(
-                                fieldWithPath("id").type(JsonFieldType.NUMBER).description("게시글식별자")
-
+                                fieldWithPath("id").type(JsonFieldType.NUMBER).description("게시글식별자"),
+                                fieldWithPath("title").type(JsonFieldType.STRING).description("제목"),
+                                fieldWithPath("content").type(JsonFieldType.STRING).description("내용"),
+                                fieldWithPath("kinds").type(JsonFieldType.STRING).description("게시물 종류"),
+                                fieldWithPath("region").type(JsonFieldType.STRING).description("지역"),
+                                fieldWithPath("postsStatus").type(JsonFieldType.STRING).description("진행상태"),
+                                fieldWithPath("headcount").type(JsonFieldType.NUMBER).description("모집인원"),
+                                fieldWithPath("meeting").type(JsonFieldType.STRING).description("미팅방법"),
+                                fieldWithPath("createAt").type(JsonFieldType.STRING).description("작성 날짜"),
+                                fieldWithPath("writer.nickname").type(JsonFieldType.STRING).description("작성자 닉네임"),
+                                fieldWithPath("writer.avatar").type(JsonFieldType.STRING).description("작성자 프로필 url"),
+                                fieldWithPath("writer.id").type(JsonFieldType.NUMBER).description("작성자 식별자"),
+                                fieldWithPath("files[].url").type(JsonFieldType.STRING).description("파일"),
+                                fieldWithPath("postSkills[]").type(JsonFieldType.ARRAY).description("게시물 스킬"),
+                                fieldWithPath("customSkills[]").type(JsonFieldType.ARRAY).description("커스텀스킬(직접입력한)"),
+                                fieldWithPath("isLike").type(JsonFieldType.BOOLEAN).description("자신이 찜한 게시물이라면 true"),
+                                fieldWithPath("teamId").type(JsonFieldType.NUMBER).description("팀 id"),
+                                fieldWithPath("refLink").type(JsonFieldType.STRING).description("참조링크").optional(),
+                                fieldWithPath("completeContent").type(JsonFieldType.STRING).description("완료게시글내용").optional()
                         )
                 ));
 


### PR DESCRIPTION
#85 
회원정보조회 프로젝트 현황 관련 수정에 앞서 필요한 PostStatus 갱신 관련 코드 수정하였습니다.
기존 코드는 삭제하지 않고 우선 주석처리했습니다.
1. PostService - changeStatus()에서 updateStatus()로 변경하면서 Post.updateStatus를 활용하여 상태변경하도록 & 수정 후 PostResponse.Info 리턴하도록 변경함
2. PostController -  changeStatus()에서  RequestBody로 받던 PostStatus 값을 RequestParam으로 수정 후 DOCS, TEST코드 모두 수정함.
3. TeamUser 평가 부분에  PostStatus에 따른 예외처리 추가함.