### PR TITLE
[backend]회원상세조회 게시물 목록조회기능 수정 

### DIFF
--- a/src/main/java/com/rubminds/api/config/SecurityConfig.java
+++ b/src/main/java/com/rubminds/api/config/SecurityConfig.java
@@ -45,7 +45,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .authorizeRequests()
                 .antMatchers("/docs/**").permitAll()
                 .antMatchers("/api/user/refreshtoken", "/api/user/login",
-                        "/api/posts","/api/post/{postId}","/api/skills", "/api/user/{userId}/posts").permitAll()
+                        "/api/posts","/api/post/{postId}","/api/skills").permitAll()
                 .anyRequest().authenticated()
                 .and()
                 .oauth2Login()

--- a/src/main/java/com/rubminds/api/post/dto/PostResponse.java
+++ b/src/main/java/com/rubminds/api/post/dto/PostResponse.java
@@ -5,8 +5,10 @@ import com.rubminds.api.post.domain.*;
 import com.rubminds.api.skill.domain.CustomSkill;
 import com.rubminds.api.skill.dto.CustomSkillResponse;
 import com.rubminds.api.skill.dto.PostSkillResponse;
+import com.rubminds.api.user.domain.User;
 import com.rubminds.api.user.security.userdetails.CustomUserDetails;
 import lombok.*;
+import org.springframework.data.domain.Page;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -145,26 +147,14 @@ public class PostResponse {
     @NoArgsConstructor(access = AccessLevel.PRIVATE)
     @AllArgsConstructor(access = AccessLevel.PRIVATE)
     public static class GetListByStatus {
-        private Long id;
-        private String writer;
-        private String title;
-        private String kinds;
-        private String region;
-        private String status;
-        private List<String> postSkills;
-        private List<String> customSkills;
+        private String nickname;
+        private Page<PostResponse.GetList> posts;
 
 
-        public static GetListByStatus build(Post post) {
+        public static GetListByStatus build(User user, Page<Post> posts, CustomUserDetails customUserDetails) {
             return GetListByStatus.builder()
-                    .id(post.getId())
-                    .writer(post.getWriter().getNickname())
-                    .title(post.getTitle())
-                    .kinds(post.getKinds().name())
-                    .region(post.getRegion())
-                    .status(post.getPostStatus().name())
-                    .postSkills(post.getPostSkills().stream().map(postSkill -> postSkill.getSkill().getName()).collect(Collectors.toList()))
-                    .customSkills(post.getCustomSkills().stream().map(customSkill -> customSkill.getName()).collect(Collectors.toList()))
+                    .nickname(user.getNickname())
+                    .posts(posts.map(post -> PostResponse.GetList.build(post, customUserDetails)))
                     .build();
         }
     }

--- a/src/main/java/com/rubminds/api/post/service/PostService.java
+++ b/src/main/java/com/rubminds/api/post/service/PostService.java
@@ -19,6 +19,8 @@ import com.rubminds.api.team.domain.TeamUser;
 import com.rubminds.api.team.domain.repository.TeamRepository;
 import com.rubminds.api.team.domain.repository.TeamUserRepository;
 import com.rubminds.api.user.domain.User;
+import com.rubminds.api.user.domain.repository.UserRepository;
+import com.rubminds.api.user.exception.UserNotFoundException;
 import com.rubminds.api.user.security.userdetails.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -44,6 +46,7 @@ public class PostService {
     private final S3Service s3Service;
     private final PostFileRepository postFileRepository;
     private final TeamUserRepository teamUserRepository;
+    private final UserRepository userRepository;
 
     @Transactional
     public PostResponse.OnlyId create(PostRequest.Create request, List<MultipartFile> files, User user) {
@@ -149,9 +152,10 @@ public class PostService {
         return posts.map(post -> PostResponse.GetList.build(post, customUserDetails));
     }
 
-    public Page<PostResponse.GetListByStatus> getListByStatus(PostStatus postStatus, Long userId, PageDto pageDto) {
+    public PostResponse.GetListByStatus getListByStatus(PostStatus postStatus, Long userId, PageDto pageDto, CustomUserDetails customUserDetails) {
+        User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
         Page<Post> posts = postRepository.findAllByStatusAndUser(postStatus, userId, pageDto.of());
-        return posts.map(post -> PostResponse.GetListByStatus.build(post));
+        return PostResponse.GetListByStatus.build(user, posts, customUserDetails);
     }
 
     public Page<PostResponse.GetList> getLikePosts(Kinds kinds, PageDto pageDto, CustomUserDetails customUserDetails) {

--- a/src/main/java/com/rubminds/api/post/web/PostController.java
+++ b/src/main/java/com/rubminds/api/post/web/PostController.java
@@ -83,10 +83,10 @@ public class PostController {
     }
 
     @GetMapping("/user/{userId}/posts")
-    public ResponseEntity<Page<PostResponse.GetListByStatus>> getListByStatus(@PathVariable Long userId,
+    public ResponseEntity<PostResponse.GetListByStatus> getListByStatus(@PathVariable Long userId,
                                                               @RequestParam(name = "status", required = false) PostStatus postStatus,
-                                                              PageDto pageDto) {
-        Page<PostResponse.GetListByStatus> response = postService.getListByStatus(postStatus, userId, pageDto);
+                                                              PageDto pageDto, @CurrentUser CustomUserDetails customUserDetails) {
+        PostResponse.GetListByStatus response = postService.getListByStatus(postStatus, userId, pageDto, customUserDetails);
         return ResponseEntity.ok().body(response);
     }
 

--- a/src/rest/PostController.http
+++ b/src/rest/PostController.http
@@ -12,6 +12,7 @@ Content-Type: application/json;charset=UTF-8
 
 ###
 GET {{apiUrl}}/user/1/posts?status=RECRUIT&page=1&size=5
+Authorization: {{authorizationToken}}
 Content-Type: application/json;charset=UTF-8
 
 ###
@@ -94,7 +95,7 @@ Content-Type: application/json;charset=UTF-8
 
 
 ###
-POST {{apiUrl}}/post/1/complete
+POST {{apiUrl}}/post/2/complete
 Authorization: {{authorizationToken}}
 Content-Type: multipart/form-data; boundary=boundary
 Accept: application/json, image/*
@@ -109,7 +110,12 @@ Content-Type: application/json;charset=UTF-8
 }
 --boundary
 Content-Disposition: form-data; name="files"; filename="white.jpeg"
-Content-Type: image/jpeg
+Content-Type: multipart/form-data
+
+< ./../main/resources/dummy/image/white.jpeg
+--boundary
+Content-Disposition: form-data; name="files"; filename="white.jpeg"
+Content-Type: multipart/form-data
 
 < ./../main/resources/dummy/image/white.jpeg
 --boundary

--- a/src/test/java/com/rubminds/api/post/web/PostControllerTest.java
+++ b/src/test/java/com/rubminds/api/post/web/PostControllerTest.java
@@ -433,10 +433,11 @@ public class PostControllerTest extends MvcTest {
     @Test
     @DisplayName("유저 게시물 목록 조회 문서화")
     public void getPostsByStatus() throws Exception {
+        CustomUserDetails customUserDetails = CustomUserDetails.create(user);
         Page<Post> postPage = new PageImpl<>(postList, PageRequest.of(1, 5), postList.size());
-        Page<PostResponse.GetListByStatus> response = postPage.map(post1 -> PostResponse.GetListByStatus.build(post1));
+        PostResponse.GetListByStatus response = PostResponse.GetListByStatus.build(user, postPage, customUserDetails);
 
-        given(postService.getListByStatus(any(), any(), any())).willReturn(response);
+        given(postService.getListByStatus(any(), any(), any(), any())).willReturn(response);
 
         ResultActions results = mvc.perform(RestDocumentationRequestBuilders.get("/api/user/{userId}/posts", 1L)
                 .param("status", "RECRUIT")
@@ -456,17 +457,18 @@ public class PostControllerTest extends MvcTest {
                                 parameterWithName("status").description("게시물 상태 (RECRUIT,WORKING,RANKING,FINISHED)")
                         ),
                         relaxedResponseFields(
-                                fieldWithPath("content[].id").type(JsonFieldType.NUMBER).description("게시글식별자"),
-                                fieldWithPath("content[].writer").type(JsonFieldType.STRING).description("작성자(닉네임)"),
-                                fieldWithPath("content[].title").type(JsonFieldType.STRING).description("제목"),
-                                fieldWithPath("content[].kinds").type(JsonFieldType.STRING).description("글 종류"),
-                                fieldWithPath("content[].region").type(JsonFieldType.STRING).description("지역"),
-                                fieldWithPath("content[].status").type(JsonFieldType.STRING).description("글 상태"),
-                                fieldWithPath("content[].postSkills[]").type(JsonFieldType.ARRAY).description("포스트 스킬 이름 목록"),
-                                fieldWithPath("content[].customSkills[]").type(JsonFieldType.ARRAY).description("커스텀 스킬 이름 목록"),
-                                fieldWithPath("totalElements").description("전체 개수"),
-                                fieldWithPath("last").description("마지막 페이지인지 식별"),
-                                fieldWithPath("totalPages").description("전체 페이지")
+                                fieldWithPath("nickname").type(JsonFieldType.STRING).description("목록 유저 닉네임"),
+                                fieldWithPath("posts.content[].id").type(JsonFieldType.NUMBER).description("게시글식별자"),
+                                fieldWithPath("posts.content[].title").type(JsonFieldType.STRING).description("제목"),
+                                fieldWithPath("posts.content[].kinds").type(JsonFieldType.STRING).description("글 종류"),
+                                fieldWithPath("posts.content[].region").type(JsonFieldType.STRING).description("지역"),
+                                fieldWithPath("posts.content[].status").type(JsonFieldType.STRING).description("글 상태"),
+                                fieldWithPath("posts.content[].skill[]").type(JsonFieldType.ARRAY).description("포스트 스킬 이름 목록"),
+                                fieldWithPath("posts.content[].customSkills[]").type(JsonFieldType.ARRAY).description("커스텀 스킬 이름 목록"),
+                                fieldWithPath("posts.content[].isLike").type(JsonFieldType.BOOLEAN).description("찜하기여부 - 찜하면 true"),
+                                fieldWithPath("posts.totalElements").description("전체 개수"),
+                                fieldWithPath("posts.last").description("마지막 페이지인지 식별"),
+                                fieldWithPath("posts.totalPages").description("전체 페이지")
                         )
                 ));
 


### PR DESCRIPTION
#108 
프론트 요청에 따라 보안제약 재수정(인증 필요하도록), 해당 회원의 닉네임 출력으로의 변경, 찜여부 다시 추가 했습니다.